### PR TITLE
Update user-agent.rkt

### DIFF
--- a/net/cookies/user-agent.rkt
+++ b/net/cookies/user-agent.rkt
@@ -406,10 +406,11 @@
 ;; domain is the "domain string", and host is the string being tested.
 (define (domain-match? domain host)
   (define diff (- (string-length host) (string-length domain)))
-  (and (diff . >= . 0)
-       (string=? domain (substring host diff))
-       (or (= diff 0) (char=? (string-ref host (sub1 diff)) #\.))
-       (not (regexp-match #px"\\.\\d\\d?\\d?$" host))))
+  (or (string=? (string-downcase domain) (string-downcase host))
+      (and (diff . >= . 0)
+           (string=? domain (substring host diff))
+           (or (= diff 0) (char=? (string-ref host (sub1 diff)) #\.))
+           (not (regexp-match #px"\\.\\d\\d?\\d?$" host)))))
 
 ;;;; As spec'd in section 5.1.4:
 


### PR DESCRIPTION
implementation of domain-match? ignores the first part of 5.3.1 of RFC 6265, which reads " The domain string and the string are identical.  (Note that both the domain string and the string will have been canonicalized to lower case at this point.)".  Rather, the function only checked the the second condition was satisfied.  This caused an error where ip-address hosts would not match to themselves.

domain-match? has been modified to fully implement 5.3.1 of RFC 6265