### PR TITLE
make-cookie should coerce name and value to strings

### DIFF
--- a/net/cookies/server.rkt
+++ b/net/cookies/server.rkt
@@ -61,7 +61,11 @@
                      #:secure?    [secure? #f]
                      #:http-only? [http-only? #f]
                      #:extension  [extension #f])
-  (cookie name value expires max-age domain path secure? http-only? extension))
+  (define (convert x)
+    (if (bytes? x)
+        (bytes->string/utf-8)
+        x))
+  (cookie (convert name) (convert value) expires max-age domain path secure? http-only? extension))
 
 ;; cookie -> String
 ;; produce a Set-Cookie header suitable for sending to a client


### PR DESCRIPTION
Currently, the contract for make-cookie accepts its name and value
args as either strings or byte-strings, but the contracts for
`cookie-name` and `cookie-value` require strings.

This means that `(define c (make-cookie #"name" #"val")` succeeds,
but `(cookie-name c)` raises an error.

This is fixed by having make-cookie convert its arguments as needed.