### PR TITLE
Relicense this repository under the Apache v2 and MIT licenses.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,10 @@
+This component of Racket is distributed under the under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
+
+See the files
+  https://github.com/racket/racket/blob/master/racket/src/LICENSE-APACHE.txt
+and
+  https://github.com/racket/racket/blob/master/racket/src/LICENSE-MIT.txt
+for the full text of the licenses.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,0 @@
-This library is distributed under the GNU Lesser General Public License
-    http://www.gnu.org/licenses/lgpl-3.0.txt
-interpreted as described by the Racket maintainers at
-    http://download.racket-lang.org/license.html
-
-Copyright (C) 2015, Jordan M. Johnson

--- a/net-cookies-doc/LICENSE.txt
+++ b/net-cookies-doc/LICENSE.txt
@@ -1,6 +1,0 @@
-This library is distributed under the GNU Lesser General Public License
-    http://www.gnu.org/licenses/lgpl-3.0.txt
-interpreted as described by the Racket maintainers at
-    http://download.racket-lang.org/license.html
-
-Copyright (C) 2015, Jordan M. Johnson

--- a/net-cookies-lib/LICENSE.txt
+++ b/net-cookies-lib/LICENSE.txt
@@ -1,6 +1,0 @@
-This library is distributed under the GNU Lesser General Public License
-    http://www.gnu.org/licenses/lgpl-3.0.txt
-interpreted as described by the Racket maintainers at
-    http://download.racket-lang.org/license.html
-
-Copyright (C) 2015, Jordan M. Johnson

--- a/net-cookies-test/LICENSE.txt
+++ b/net-cookies-test/LICENSE.txt
@@ -1,6 +1,0 @@
-This library is distributed under the GNU Lesser General Public License
-    http://www.gnu.org/licenses/lgpl-3.0.txt
-interpreted as described by the Racket maintainers at
-    http://download.racket-lang.org/license.html
-
-Copyright (C) 2015, Jordan M. Johnson

--- a/net-cookies/LICENSE.txt
+++ b/net-cookies/LICENSE.txt
@@ -1,6 +1,0 @@
-This library is distributed under the GNU Lesser General Public License
-    http://www.gnu.org/licenses/lgpl-3.0.txt
-interpreted as described by the Racket maintainers at
-    http://download.racket-lang.org/license.html
-
-Copyright (C) 2015, Jordan M. Johnson


### PR DESCRIPTION
This follows the general Racket relicensing effort;
see racket/racket#1570.

All the other contributors to this repository have signed off on
changing the license of their Racket contributions.