### PR TITLE
Reduce memory utilization

### DIFF
--- a/net-cookies-lib/info.rkt
+++ b/net-cookies-lib/info.rkt
@@ -3,5 +3,5 @@
 (define collection 'multi)
 (define pkg-desc "implementation (no documentation) part of \"net-cookies\"")
 (define deps '("base"))
-(define version "1.1.4")
+(define version "1.2")
 (define license '(Apache-2.0 OR MIT))

--- a/net-cookies-lib/info.rkt
+++ b/net-cookies-lib/info.rkt
@@ -2,6 +2,6 @@
 
 (define collection 'multi)
 (define pkg-desc "implementation (no documentation) part of \"net-cookies\"")
-(define deps '("srfi-lite-lib" "base"))
+(define deps '("base"))
 (define version "1.1.4")
 (define license '(Apache-2.0 OR MIT))

--- a/net-cookies-lib/info.rkt
+++ b/net-cookies-lib/info.rkt
@@ -1,16 +1,7 @@
 #lang info
 
-;; for net-cookies-lib
-
 (define collection 'multi)
-
-(define pkg-desc
-  "implementation (no documentation) part of \"net-cookies\"")
-
+(define pkg-desc "implementation (no documentation) part of \"net-cookies\"")
 (define deps '("srfi-lite-lib" "base"))
-
 (define version "1.1.4")
-
-
-(define license
-  '(Apache-2.0 OR MIT))
+(define license '(Apache-2.0 OR MIT))

--- a/net-cookies-lib/net/cookies.rkt
+++ b/net-cookies-lib/net/cookies.rkt
@@ -1,7 +1,9 @@
 #lang racket/base
 
-(require "cookies/common.rkt" "cookies/server.rkt" "cookies/user-agent.rkt")
-(provide (all-from-out "cookies/common.rkt"
-                       "cookies/server.rkt"
-                       "cookies/user-agent.rkt"))
-
+(require "cookies/common.rkt"
+         "cookies/server.rkt"
+         "cookies/user-agent.rkt")
+(provide
+ (all-from-out "cookies/common.rkt"
+               "cookies/server.rkt"
+               "cookies/user-agent.rkt"))

--- a/net-cookies-lib/net/cookies/common.rkt
+++ b/net-cookies-lib/net/cookies/common.rkt
@@ -1,17 +1,23 @@
-#lang racket
+#lang racket/base
 
-(provide (contract-out
-          [cookie-name? (-> any/c boolean?)]
-          [cookie-value? (-> any/c boolean?)]
-          [path/extension-value? (-> any/c boolean?)]
-          [domain-value? (-> any/c boolean?)]
-          ))
+(require racket/contract/base
+         racket/match
+         racket/string)
 
-(require racket/match)
+(provide
+ (contract-out
+  [cookie-name? (-> any/c boolean?)]
+  [cookie-value? (-> any/c boolean?)]
+  [path/extension-value? (-> any/c boolean?)]
+  [domain-value? (-> any/c boolean?)]))
 
 ;;;;;;;;; Cookie names ;;;;;;;;;
 
-(require srfi/13 srfi/14) ; for charsets, and testing strings against them
+(require srfi/14) ; for charsets, and testing strings against them
+
+(define (string-every cs s)
+  (for/and ([c (in-string s)])
+    (char-set-contains? cs c)))
 
 ;; cookie-name? : Any -> Bool
 ;; true iff s is a token, per RFC6265; see below
@@ -30,10 +36,12 @@
 ;;                | "{" | "}" | SP | HT
 ;; see also RFC2616 Sec 2.2
 
+(define separators
+  (bytes->list #"()<>@,;:\\\"/[]?={} \t"))
 (define (token-byte? b)
   (and (< 31 b 127) (not (separator-byte? b)))) ; exclude CTLs and seps
 (define (separator-byte? b)
-  (member b (bytes->list #"()<>@,;:\\\"/[]?={} \t")))
+  (memv b separators))
 
 (define char-set:separators
   (char-set-union (string->char-set "()<>@,;:\\\"/[]?={}")

--- a/net-cookies-lib/net/cookies/common.rkt
+++ b/net-cookies-lib/net/cookies/common.rkt
@@ -11,23 +11,16 @@
   [path/extension-value? (-> any/c boolean?)]
   [domain-value? (-> any/c boolean?)]))
 
+
 ;;;;;;;;; Cookie names ;;;;;;;;;
-
-(require srfi/14) ; for charsets, and testing strings against them
-
-(define (string-every cs s)
-  (for/and ([c (in-string s)])
-    (char-set-contains? cs c)))
 
 ;; cookie-name? : Any -> Bool
 ;; true iff s is a token, per RFC6265; see below
+(define cookie-name-re
+  (pregexp (format "^[^~a]+$" (regexp-quote "()<>@,;:\\\"/[]?={} \t"))))
+
 (define (cookie-name? s)
-  (or (and (bytes? s)
-           (not (zero? (bytes-length s)))
-           (for/and ([b (in-bytes s)]) (token-byte? b)))
-      (and (string? s)
-           (not (zero? (string-length s)))
-           (string-every char-set:token s))))
+  (regexp-match? cookie-name-re s))
 
 ;; token          = 1*<any CHAR except CTLs or separators>
 ;; separator      = "(" | ")" | "<" | ">" | "@"
@@ -36,21 +29,6 @@
 ;;                | "{" | "}" | SP | HT
 ;; see also RFC2616 Sec 2.2
 
-(define separators
-  (bytes->list #"()<>@,;:\\\"/[]?={} \t"))
-(define (token-byte? b)
-  (and (< 31 b 127) (not (separator-byte? b)))) ; exclude CTLs and seps
-(define (separator-byte? b)
-  (memv b separators))
-
-(define char-set:separators
-  (char-set-union (string->char-set "()<>@,;:\\\"/[]?={}")
-                  char-set:whitespace
-                  (char-set #\tab)))
-(define char-set:control
-  (char-set-union char-set:iso-control (char-set (integer->char 127))));; DEL
-(define char-set:token
-  (char-set-difference char-set:ascii char-set:separators char-set:control))
 
 ;;;;;;;;; Cookie values ;;;;;;;;;
 
@@ -59,31 +37,36 @@
 ;;   cookie-value    = *cookie-octet
 ;;                   / ( DQUOTE *cookie-octet DQUOTE )
 ;; where cookie-octet is defined below
-(define (cookie-value? x)
-  (or (and (bytes? x)
-           (let ([len (bytes-length x)])
-             (or (and (>= len 2)
-                      (= (bytes-ref x 0) DQUOTE)
-                      (= (bytes-ref x (- len 1)) DQUOTE)
-                      (all-cookie-octets? (subbytes x 1 (- len 1))))
-                 (all-cookie-octets? x))))
-      (and (string? x)
-           (or (string-every char-set:cookie-octets x)
-               (let ([m (regexp-match #rx"^\"(.*)\"$" x)])
-                 (match m
-                   [(list _ quoted-text)
-                    (string-every char-set:cookie-octets quoted-text)]
-                   [_ #f]))))))
+(define (cookie-value? value)
+  (match value
+    [(regexp #rx"^\"(.*)\"" (list _ quoted-value))
+     (cookie-value?* quoted-value)]
+    [_
+     (cookie-value?* value)]))
 
-(define (all-cookie-octets? x)
-  (for/and ([b (in-bytes x)]) (cookie-octet-byte? b)))
-(define DQUOTE #x22)
+(define cookie-value-re
+  (pregexp (format "^[~a0-9A-Za-z\\-]*$" (regexp-quote "()!#$%&'*+./:<=>?@[]^_{|}~"))))
+(define (cookie-value?* value)
+  (regexp-match? cookie-value-re value))
+
 ;; From the RFC:
 ;;      path-value = *av-octet
 ;;    extension-av = *av-octet
 ;; where av-octet is defined below.
 (define (path/extension-value? x) ; : Any -> Boolean
-  (and (string? x) (string-every char-set:av-octets x)))
+  (and (string? x)
+       (regexp-match? av-octets-re x)))
+
+(define av-octets-re
+  (pregexp (format "^[^~a]*$" (regexp-quote
+                               (string-append
+                                (apply
+                                 string
+                                 (cons
+                                  (integer->char 127)
+                                  (for/list ([code (in-range 0 32)])
+                                    (integer->char code))))
+                                "#\\;")))))
 
 
 ;; Per RFC1034.3.5 (with the RFC1123 revision to allow domain name
@@ -101,12 +84,12 @@
 ;;                     ; as def'd in RFC1034 Sec 3.5
 ;;                     ; and enhanced by RFC1123 Sec 2.1
 (define (domain-value? dom) ; Any -> Boolean
-  (or (and (string? dom)
+  (and (string? dom)
        (let ([parts (string-split dom "." #:trim? #f)])
          (and (not (null? parts))
               (for/and ([part parts])
                 (regexp-match domain-label-rx part))))
-       #t)))
+       #t))
 
 ;;;; Underlying charsets
 
@@ -119,19 +102,3 @@
 ;; Charset used in cookie values includes the following chars:
 ;; ( ) ! # $ % & '  * + - . / 0 1 2 3 4 5 6 7 8 9 : < = > ? @ [ ] ^ _ `
 ;; { | } ~ A-Z a-z
-
-(define (cookie-octet-byte? x)
-  (and (< 31 x 127) (not (memv x non-cookie-octet-bytes))))
-(define non-cookie-octet-bytes (map char->integer (string->list " \t\",;\\")))
-
-(define char-set:cookie-octets
-  (char-set-difference char-set:ascii
-                       char-set:control char-set:whitespace
-                       (string->char-set "\",;\\")))
-
-;; Chars used in path-av and extension-av values:
-#;
-(define (cookie-av-octet-byte? x)
-  (and (< 31 x 127) (not (= x #x3B)))) ; #x3B is #\;
-(define char-set:av-octets
-  (char-set-difference char-set:ascii char-set:control (char-set #\;)))

--- a/net-cookies-lib/net/cookies/server.rkt
+++ b/net-cookies-lib/net/cookies/server.rkt
@@ -1,52 +1,50 @@
 #lang racket/base
 
-(require racket/contract
-         (only-in racket/bytes bytes-join)
+(require racket/bytes
+         racket/contract/base
+         racket/match
+         racket/serialize ; for serializable cookie structs
+         racket/string
+         srfi/19 ; for date handling
          "common.rkt")
 
-(provide (contract-out (struct cookie
-                         ([name       (and/c string? cookie-name?)]
-                          [value      (and/c string? cookie-value?)]
-                          [expires    (or/c date? #f)]
-                          [max-age    (or/c (and/c integer? positive?) #f)]
-                          [domain     (or/c domain-value? #f)]
-                          [path       (or/c path/extension-value? #f)]
-                          [secure?    boolean?]
-                          [http-only? boolean?]
-                          [extension  (or/c path/extension-value? #f)])
-                         #:omit-constructor)
-                       [make-cookie
-                        (->* (cookie-name? cookie-value?)
-                             (#:expires    (or/c date? #f)
-                              #:max-age    (or/c (and/c integer? positive?) #f)
-                              #:domain     (or/c domain-value? #f)
-                              #:path       (or/c path/extension-value? #f)
-                              #:secure?    boolean?
-                              #:http-only? boolean?
-                              #:extension  (or/c path/extension-value? #f))
-                             cookie?)]
-                       
-                       [cookie->set-cookie-header (-> cookie? bytes?)]
-                       [clear-cookie-header
-                        (->* (cookie-name?)
-                             (#:domain     (or/c domain-value? #f)
-                              #:path       (or/c path/extension-value? #f))
-                             bytes?)]
-                       [cookie->string (-> cookie? string?)]
-                       
-                       #:forall X
-                       [cookie-header->alist
-                        (case-> (-> bytes? (listof (cons/c bytes? bytes?)))
-                                (-> bytes? (-> bytes? X)
-                                    (listof (cons/c X X))))]
-                       ))
+(provide
+ (contract-out
+  (struct cookie
+    ([name       (and/c string? cookie-name?)]
+     [value      (and/c string? cookie-value?)]
+     [expires    (or/c date? #f)]
+     [max-age    (or/c (and/c integer? positive?) #f)]
+     [domain     (or/c domain-value? #f)]
+     [path       (or/c path/extension-value? #f)]
+     [secure?    boolean?]
+     [http-only? boolean?]
+     [extension  (or/c path/extension-value? #f)])
+    #:omit-constructor)
+  [make-cookie
+   (->* (cookie-name? cookie-value?)
+        (#:expires    (or/c date? #f)
+         #:max-age    (or/c (and/c integer? positive?) #f)
+         #:domain     (or/c domain-value? #f)
+         #:path       (or/c path/extension-value? #f)
+         #:secure?    boolean?
+         #:http-only? boolean?
+         #:extension  (or/c path/extension-value? #f))
+        cookie?)]
 
-(require racket/serialize ; for serializable cookie structs
-         srfi/19          ; for date handling
-         (only-in racket/string
-                  string-join string-split)
-         racket/match
-         )
+  [cookie->set-cookie-header (-> cookie? bytes?)]
+  [clear-cookie-header
+   (->* (cookie-name?)
+        (#:domain     (or/c domain-value? #f)
+         #:path       (or/c path/extension-value? #f))
+        bytes?)]
+  [cookie->string (-> cookie? string?)]
+
+  #:forall X
+  [cookie-header->alist
+   (case-> (-> bytes? (listof (cons/c bytes? bytes?)))
+           (-> bytes? (-> bytes? X)
+               (listof (cons/c X X))))]))
 
 
 (serializable-struct cookie
@@ -131,37 +129,36 @@
 #|
 From RFC6265:
 
-   HTTP applications have historically allowed three different formats
-   for the representation of date/time stamps:
+HTTP applications have historically allowed three different formats
+for the representation of date/time stamps:
 
-      Sun, 06 Nov 1994 08:49:37 GMT  ; RFC 822, updated by RFC 1123
-      Sunday, 06-Nov-94 08:49:37 GMT ; RFC 850, obsoleted by RFC 1036
-      Sun Nov  6 08:49:37 1994       ; ANSI C's asctime() format
+Sun, 06 Nov 1994 08:49:37 GMT  ; RFC 822, updated by RFC 1123
+Sunday, 06-Nov-94 08:49:37 GMT ; RFC 850, obsoleted by RFC 1036
+Sun Nov  6 08:49:37 1994       ; ANSI C's asctime() format
 
-   The first format is preferred as an Internet standard and represents
-   a fixed-length subset of that defined by RFC 1123 [8] (an update to
-   RFC 822 [9]). The second format is in common use, but is based on the
-   obsolete RFC 850 [12] date format and lacks a four-digit year.
-   HTTP/1.1 clients and servers that parse the date value MUST accept
-   all three formats (for compatibility with HTTP/1.0), though they MUST
-   only generate the RFC 1123 format for representing HTTP-date values
-   in header fields...
+The first format is preferred as an Internet standard and represents
+a fixed-length subset of that defined by RFC 1123 [8] (an update to
+RFC 822 [9]). The second format is in common use, but is based on the
+obsolete RFC 850 [12] date format and lacks a four-digit year.
+HTTP/1.1 clients and servers that parse the date value MUST accept
+all three formats (for compatibility with HTTP/1.0), though they MUST
+only generate the RFC 1123 format for representing HTTP-date values
+in header fields...
 
-      Note: Recipients of date values are encouraged to be robust in
-      accepting date values that may have been sent by non-HTTP
-      applications, as is sometimes the case when retrieving or posting
-      messages via proxies/gateways to SMTP or NNTP.
+Note: Recipients of date values are encouraged to be robust in
+accepting date values that may have been sent by non-HTTP
+applications, as is sometimes the case when retrieving or posting
+messages via proxies/gateways to SMTP or NNTP.
 
-   All HTTP date/time stamps MUST be represented in Greenwich Mean Time
-   (GMT), without exception. For the purposes of HTTP, GMT is exactly
-   equal to UTC (Coordinated Universal Time). This is indicated in the
-   first two formats by the inclusion of "GMT" as the three-letter
-   abbreviation for time zone, and MUST be assumed when reading the
-   asctime format. HTTP-date is case sensitive and MUST NOT include
-   additional LWS beyond that specifically included as SP in the
-   grammar.
+All HTTP date/time stamps MUST be represented in Greenwich Mean Time
+(GMT), without exception. For the purposes of HTTP, GMT is exactly
+equal to UTC (Coordinated Universal Time). This is indicated in the
+first two formats by the inclusion of "GMT" as the three-letter
+abbreviation for time zone, and MUST be assumed when reading the
+asctime format. HTTP-date is case sensitive and MUST NOT include
+additional LWS beyond that specifically included as SP in the
+grammar.
 |#
 (define rfc1123:date-template "~a, ~d ~b ~Y ~H:~M:~S GMT")
 (define rfc850:date-template "~A, ~d-~b-~y ~H:~M:~S GMT")
 (define asctime:date-template "~a ~b ~e ~H:~M:~S ~Y")
-

--- a/net-cookies-lib/net/cookies/user-agent.rkt
+++ b/net-cookies-lib/net/cookies/user-agent.rkt
@@ -1,21 +1,19 @@
 #lang racket/base
 
-(require racket/contract/base
+(require net/url ; used in path matching
+         racket/bytes
+         racket/contract/base
          racket/class ; for cookie-jar interface & class
+         (only-in racket/date date->seconds)
          racket/list
          racket/match
-         (only-in racket/bytes bytes-join) ; for building the Cookie: header
-         srfi/19
+         racket/string
          "common.rkt"
          ;web-server/http/request-structs
          ; The above is commented out because, although it'd be clean to reuse
          ; header structs, I don't want to create a dependency on the
          ; web-server-lib package. I'm leaving it in as comments, in case
          ; net/head acquires a similar facility at some point.
-         net/url ; used in path matching
-         (only-in racket/date date->seconds)
-         (only-in racket/string string-join string-trim string-split)
-         (only-in srfi/13 string-index-right)
          )
 
 (struct ua-cookie [name value domain path
@@ -23,57 +21,56 @@
                         persistent? host-only? secure-only? http-only?]
   #:transparent)
 
-(provide (contract-out
-          (struct ua-cookie ([name            cookie-name?]
-                             [value           cookie-value?]
-                             [domain          domain-value?]
-                             [path            path/extension-value?]
-                             [expiration-time integer?]
-                             [creation-time   (and/c integer? positive?)]
-                             [access-time     (and/c integer? positive?)]
-                             [persistent?     boolean?]
-                             [host-only?      boolean?]
-                             [secure-only?    boolean?]
-                             [http-only?      boolean?]))
+(provide
+ (contract-out
+  (struct ua-cookie ([name            cookie-name?]
+                     [value           cookie-value?]
+                     [domain          domain-value?]
+                     [path            path/extension-value?]
+                     [expiration-time integer?]
+                     [creation-time   (and/c integer? positive?)]
+                     [access-time     (and/c integer? positive?)]
+                     [persistent?     boolean?]
+                     [host-only?      boolean?]
+                     [secure-only?    boolean?]
+                     [http-only?      boolean?]))
 
-          [extract-and-save-cookies!
-           (->* ((or/c (listof (cons/c bytes? bytes?))
-                       (listof bytes?))
-                 url?)
-                ((-> bytes? string?))
-               void?)]
-          [save-cookie! (->* (ua-cookie?) (boolean?) void?)]
-          [cookie-header (->* (url?)
-                              ((-> string? bytes?)
-                               #:filter-with (-> ua-cookie? boolean?))
-                              (or/c bytes? #f))]
+  [extract-and-save-cookies!
+   (->* ((or/c (listof (cons/c bytes? bytes?))
+               (listof bytes?))
+         url?)
+        ((-> bytes? string?))
+        void?)]
+  [save-cookie! (->* (ua-cookie?) (boolean?) void?)]
+  [cookie-header (->* (url?)
+                      ((-> string? bytes?)
+                       #:filter-with (-> ua-cookie? boolean?))
+                      (or/c bytes? #f))]
 
-          [cookie-expired? (->* (ua-cookie?) ((and/c integer? positive?))
-                                boolean?)]
-          [current-cookie-jar (parameter/c (is-a?/c cookie-jar<%>))]
-          [list-cookie-jar%
-           (class/c [save-cookies! (->*m ((listof ua-cookie?)) (boolean?) void?)]
-                    [save-cookie!  (->*m (ua-cookie?)          (boolean?) void?)]
-                    [cookies-matching
-                     (->*m (url?) (boolean?) (listof ua-cookie?))])]
+  [cookie-expired? (->* (ua-cookie?) ((and/c integer? positive?))
+                        boolean?)]
+  [current-cookie-jar (parameter/c (is-a?/c cookie-jar<%>))]
+  [list-cookie-jar%
+   (class/c [save-cookies! (->*m ((listof ua-cookie?)) (boolean?) void?)]
+            [save-cookie!  (->*m (ua-cookie?)          (boolean?) void?)]
+            [cookies-matching
+             (->*m (url?) (boolean?) (listof ua-cookie?))])]
 
-          [extract-cookies
-           (->* ((or/c (listof (cons/c bytes? bytes?))
-                       (listof bytes?))
-                 ;(listof (or/c header? (cons/c bytes? bytes?)))
-                 url?)
-                ((-> bytes? string?))
-                (listof ua-cookie?))]
-          [parse-cookie (->* (bytes? url?) ((-> bytes? string?)) (or/c ua-cookie? #f))]
+  [extract-cookies
+   (->* ((or/c (listof (cons/c bytes? bytes?))
+               (listof bytes?))
+         ;(listof (or/c header? (cons/c bytes? bytes?)))
+         url?)
+        ((-> bytes? string?))
+        (listof ua-cookie?))]
+  [parse-cookie (->* (bytes? url?) ((-> bytes? string?)) (or/c ua-cookie? #f))]
 
-          [default-path (-> url? string?)]
+  [default-path (-> url? string?)]
 
-          [min-cookie-seconds (and/c integer? negative?)]
-          [max-cookie-seconds (and/c integer? positive?)]
-          [parse-date    (-> string? (or/c date? #f))]
-          )
-         cookie-jar<%>
-         )
+  [min-cookie-seconds (and/c integer? negative?)]
+  [max-cookie-seconds (and/c integer? positive?)]
+  [parse-date (-> string? (or/c date? #f))])
+ cookie-jar<%>)
 
 ;;;;;;;;;;;;;;;;;;;;; Storing Cookies ;;;;;;;;;;;;;;;;;;;;;
 
@@ -453,6 +450,11 @@
            (not (regexp-match #px"\\.\\d\\d?\\d?$" host)))))
 
 ;;;; As spec'd in section 5.1.4:
+
+(define (string-index-right s c)
+  (for/first ([idx (in-range (sub1 (string-length s)) -1 -1)]
+              #:when (eqv? (string-ref s idx) c))
+    idx))
 
 ;; url? -> string?
 ;; compute the default-path of a cookie, for use in creating the ua-cookie struct

--- a/net-cookies-lib/net/cookies/user-agent.rkt
+++ b/net-cookies-lib/net/cookies/user-agent.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(require racket/contract
+(require racket/contract/base
          racket/class ; for cookie-jar interface & class
          racket/list
          racket/match
@@ -51,7 +51,7 @@
           [cookie-expired? (->* (ua-cookie?) ((and/c integer? positive?))
                                 boolean?)]
           [current-cookie-jar (parameter/c (is-a?/c cookie-jar<%>))]
-          [list-cookie-jar% 
+          [list-cookie-jar%
            (class/c [save-cookies! (->*m ((listof ua-cookie?)) (boolean?) void?)]
                     [save-cookie!  (->*m (ua-cookie?)          (boolean?) void?)]
                     [cookies-matching
@@ -182,7 +182,7 @@
              [(cookie-ok? (car jar))
               (cons (car jar) (insert-into (cdr jar)))]
              [else (insert-into (cdr jar))])])))
-    
+
     ;; String^3 (listof ua-cookie) -> (maybe ua-cookie)
     ;; produces all cookies in jar that do not have the given combo of name/dom/path
     (define (remove-cookie-matching name dom path jar)
@@ -248,10 +248,10 @@
   (let/ec esc
     (define (ignore-this-Set-Cookie) (esc #f))
     (define now (current-seconds))
-    
+
     (match-define (list-rest nvpair unparsed-attributes)
       (string-split (decode set-cookie-bytes) ";"))
-    
+
     (define-values (name value)
       (match (regexp-match nvpair-regexp nvpair)
         [(list all "" v) (ignore-this-Set-Cookie)]
@@ -260,7 +260,7 @@
 
     ;;; parsing the unparsed-attributes
     (define-values (domain-attribute path expires max-age secure? http-only?)
-      (parse-cookie-attributes unparsed-attributes url))   
+      (parse-cookie-attributes unparsed-attributes url))
 
     (define-values (host-only? domain)
       (let ([request-host (url-host url)])
@@ -486,11 +486,9 @@
       [(url? url)    (url-full-path url)]))
   (define cookie-len (string-length cookie-path))
   (define request-path-len (string-length request-path))
-  
+
   (and (<= cookie-len request-path-len)
        (string=? (substring request-path 0 cookie-len) cookie-path)
        (or (char=? (string-ref cookie-path (sub1 cookie-len)) #\/)
            (and (< cookie-len request-path-len)
                 (char=? (string-ref request-path cookie-len) #\/)))))
-
-


### PR DESCRIPTION
I've recently started looking into reducing the memory use of one of my apps, and `net/cookies` is one if its transitive dependencies (via `net/http-easy`) that adds a sizeable amount of overhead. To that end, I've made some changes to the library to use regular Racket instead of bringing in the SRFI libraries as well as optimized the imports a little (eg. to use `racket/contract/base` instead of `racket/contract` and `#lang racket/base` instead of `#lang racket`). Without these changes, requiring this library increases memory usage by about 50MB under Racket CS on my machine:

```
$ racket -l racket/base -e '(define s (current-memory-use)) (require net/cookies) (- (current-memory-use) s)' | awk '{print $1/1024/1024}'
50.3859
```

After this change, that number drops down to about 34MB:

```
$ racket -l racket/base -e '(define s (current-memory-use)) (require net/cookies) (- (current-memory-use) s)' | awk '{print $1/1024/1024}'
34.2828
```

To get further improvements, I'll have to look at `net/url` in the main distribution, since that's the next biggest contributor that `net/cookies` depends on.