### PR TITLE
add missing backtick char to cookie-value? re and ctl chars to cookie-name? re

### DIFF
--- a/net-cookies-lib/net/cookies/common.rkt
+++ b/net-cookies-lib/net/cookies/common.rkt
@@ -45,7 +45,7 @@
      (cookie-value?* value)]))
 
 (define cookie-value-re
-  (pregexp (format "^[~a0-9A-Za-z\\-]*$" (regexp-quote "()!#$%&'*+./:<=>?@[]^_{|}~"))))
+  (pregexp (format "^[~a0-9A-Za-z\\-]*$" (regexp-quote "()!#$%&'*+./:<=>?@[]^_{|}~`"))))
 (define (cookie-value?* value)
   (regexp-match? cookie-value-re value))
 

--- a/net-cookies-lib/net/cookies/common.rkt
+++ b/net-cookies-lib/net/cookies/common.rkt
@@ -16,8 +16,19 @@
 
 ;; cookie-name? : Any -> Bool
 ;; true iff s is a token, per RFC6265; see below
+(define control-characters
+  (apply string (cons
+                 (integer->char 127)
+                 (for/list ([code (in-range 0 32)])
+                   (integer->char code)))))
 (define cookie-name-re
-  (pregexp (format "^[^~a]+$" (regexp-quote "()<>@,;:\\\"/[]?={} \t"))))
+  (pregexp
+   (format
+    "^[^~a]+$"
+    (regexp-quote
+     (string-append
+      control-characters
+      "()<>@,;:\\\"/[]?={} ")))))
 
 (define (cookie-name? s)
   (regexp-match? cookie-name-re s))
@@ -58,15 +69,13 @@
        (regexp-match? av-octets-re x)))
 
 (define av-octets-re
-  (pregexp (format "^[^~a]*$" (regexp-quote
-                               (string-append
-                                (apply
-                                 string
-                                 (cons
-                                  (integer->char 127)
-                                  (for/list ([code (in-range 0 32)])
-                                    (integer->char code))))
-                                "#\\;")))))
+  (pregexp
+   (format
+    "^[^~a]*$"
+    (regexp-quote
+     (string-append
+      control-characters
+      "#\\;")))))
 
 
 ;; Per RFC1034.3.5 (with the RFC1123 revision to allow domain name

--- a/net-cookies-test/tests/net/cookies/common.rkt
+++ b/net-cookies-test/tests/net/cookies/common.rkt
@@ -35,7 +35,7 @@
 
 (define-test-suite cookie-value-tests
   (test-cookie-pred "cookie values" cookie-value? #t
-    (valid "value" "(" "!" ")" ")!" "(!" "(!)" "!)" "\"hey!\"" "a=b=c")
+    (valid "value" "(" "!" ")" ")!" "(!" "(!)" "!)" "\"hey!\"" "a=b=c" "`a")
     (invalid "a;b" "a,b" "a b" "a\tb" "a=\"foo\"")))
 
 (define-test-suite p/e-value-tests

--- a/net-cookies-test/tests/net/cookies/common.rkt
+++ b/net-cookies-test/tests/net/cookies/common.rkt
@@ -29,7 +29,7 @@
   (test-cookie-pred "cookie names" cookie-name? #t
     (valid "HI" "hi" "Hi" "modestlyLongCookieName"
            "somewhatTremendouslyOverlongCookieNameThatTakesAWhileToType")
-    (invalid "(ugh)" "\"" "\"argh\"" "<tags>" "foo@bar"
+    (invalid "\0" "hello\n" "\t" "\u7F" "(ugh)" "\"" "\"argh\"" "<tags>" "foo@bar"
              ",,,,,chameleon" "this;that" "this:that" "[bracketed]" "{braced}"
              "slashed/" "back\\slashed" "what?" "x=y" "spaced out" "\ttabbed")))
 


### PR DESCRIPTION
This fixes the issue introduced by #15.