### PR TITLE
fix empty set-cookie header throwing internal exception

### DIFF
--- a/net-cookies-lib/net/cookies/user-agent.rkt
+++ b/net-cookies-lib/net/cookies/user-agent.rkt
@@ -246,8 +246,11 @@
     (define (ignore-this-Set-Cookie) (esc #f))
     (define now (current-seconds))
 
-    (match-define (list-rest nvpair unparsed-attributes)
-      (string-split (decode set-cookie-bytes) ";"))
+    (define attributes (string-split (decode set-cookie-bytes) ";"))
+    (when (null? attributes)
+      (ignore-this-Set-Cookie))
+
+    (match-define (list-rest nvpair unparsed-attributes) attributes)
 
     (define-values (name value)
       (match (regexp-match nvpair-regexp nvpair)

--- a/net-cookies-test/tests/net/cookies/user-agent.rkt
+++ b/net-cookies-test/tests/net/cookies/user-agent.rkt
@@ -791,6 +791,7 @@
                 test-example-url)))
   
   ;; Cookie parsing failures:
+  (test-false "empty Set-Cookie header" (parse-cookie #"" example-url))
   (test-false "no equals in nvpair" (parse-cookie #"foo" example-url))
   (test-false "no equals in nvpair" (parse-cookie #"foo;" example-url))
   (test-false "no cookie name" (parse-cookie #"=foo" example-url))


### PR DESCRIPTION
When header is simply `Set-Cookie:` with no value, it can't parse it.

```
match-define: no matching clause for '()
  location...:
   /var/home/cadence/.racket/share/pkgs/net-cookies-lib/net/cookies/user-agent.rkt:249:4
  context...:
   /var/home/cadence/.racket/share/pkgs/net-cookies-lib/net/cookies/user-agent.rkt:245:2
   /var/home/cadence/.racket/share/pkgs/net-cookies-lib/net/cookies/user-agent.rkt:227:0: extract-cookies
   /var/home/cadence/.racket/share/pkgs/net-cookies-lib/net/cookies/user-agent.rkt:78:0: extract-and-save-cookies!
```

Now it can.

Maybe there's a clever way to do this in a single match-define by adding more match clauses, but I don't have enough abstract thought powers to make that a reality. This still works.